### PR TITLE
feat(.npmrc): Add hardened .npmrc (7-day min-release-age) for npm supply chain protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [master, add-hardened-npmrc]
+  pull_request:
+    branches: [master]
+
+jobs:
+  validate-npmrc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify .npmrc exists and contains required settings
+        run: |
+          test -f .npmrc || (echo ".npmrc not found" && exit 1)
+          grep -q "min-release-age=7" .npmrc || (echo "min-release-age=7 missing" && exit 1)
+          grep -q "ignore-scripts=true" .npmrc || (echo "ignore-scripts=true missing" && exit 1)
+          grep -q "save-exact=true" .npmrc || (echo "save-exact=true missing" && exit 1)
+          grep -q "package-lock=true" .npmrc || (echo "package-lock=true missing" && exit 1)
+          echo "All .npmrc hardening settings verified"

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+min-release-age=7
+ignore-scripts=true
+save-exact=true
+package-lock=true


### PR DESCRIPTION
## Summary

Add `.npmrc` to the repository root with hardened settings to protect against npm supply chain attacks (e.g., Mini Shai-Hulud npm worm).

The following settings are applied:

- `min-release-age=7` — Requires packages to be at least 7 days old before installation, blocking newly published malicious packages
- `ignore-scripts=true` — Prevents execution of lifecycle scripts (install/postinstall) which are the primary vector for supply chain attacks
- `save-exact=true` — Pins exact versions in package.json to prevent unexpected version drift
- `package-lock=true` — Ensures package-lock.json is always maintained for reproducible installs

## Verification

`npm install` completes successfully with these settings in place (verified locally with npm 11.14.1).

## Demo Video

https://github.com/user-attachments/assets/d7e9ea5b-d358-4971-afc6-3d56da60df57

- close HiromiShikata/umino-corporait-operation#28793